### PR TITLE
2 searching by title or author uppercase bug

### DIFF
--- a/LibraryBackend.Tests/UnitTestBookController.cs
+++ b/LibraryBackend.Tests/UnitTestBookController.cs
@@ -351,7 +351,7 @@ namespace LibraryBackend.Tests
       var notFoundResult = Assert.IsType<NotFoundObjectResult>(emptyBookList.Result);
       _mockBookRepository.Verify(mockRepository => mockRepository.FindByConditionAsync(
         It.IsAny<Expression<Func<Book, bool>>>()), Times.Once);
-      Assert.Equal($"Book with Title or Author '{nonExistingTitleOrAuthor}' not found", notFoundResult.Value);
+      Assert.Equal($"Book with Title or Author '{nonExistingTitleOrAuthor.ToLower()}' not found", notFoundResult.Value);
     }
 
     [Fact]

--- a/LibraryBackend/Controllers/BookController.cs
+++ b/LibraryBackend/Controllers/BookController.cs
@@ -134,6 +134,7 @@ namespace LibraryBackend.Controllers
         };
         return BadRequest(error);
       }
+      titleOrAuthor = titleOrAuthor.ToLower(); 
       Expression<Func<Book, bool>> condition = book => 
         book.Title!.ToLower().Contains(titleOrAuthor) 
         || 


### PR DESCRIPTION
Update 'Should_return_NotFound_for_non_existing_title' test to verify  changes in 'titleOrAuthor' case in UnitTestBookController.cs

Convert titleOrAuthor in lower case and made 'Should_return_NotFound_for_non_existing_title_or_author...' test passed
